### PR TITLE
Add missing param knob value popups

### DIFF
--- a/Hairball.jucer
+++ b/Hairball.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="LBaNls" name="Hairball" projectType="audioplug" jucerVersion="5.4.3"
               companyName="Artisanal Computing" pluginFormats="buildAU,buildVST"
-              companyEmail="artisanalcomputing@gmail.com" version="0.2.0" pluginChannelConfigs="{1, 1}, {2, 2}">
+              companyEmail="artisanalcomputing@gmail.com" version="0.2.1" pluginChannelConfigs="{1, 1}, {2, 2}">
   <MAINGROUP id="jIpEeo" name="Hairball">
     <GROUP id="{D72BE97B-1838-822A-5A43-418D243172E1}" name="Panels">
       <FILE id="l5VCQR" name="HairballMainPanel.cpp" compile="1" resource="0"

--- a/Source/HairballMainPanel.cpp
+++ b/Source/HairballMainPanel.cpp
@@ -26,15 +26,17 @@ HairballMainPanel::HairballMainPanel(HairballAudioProcessor* inProcessor)
     
     mRangeSlider.reset(new HairballParameterSlider(mProcessor->parameters, HairballParameterID[hParameter_Range], HairballParameterLabel[hParameter_Range]));
     mRangeSlider->setBounds(getWidth() - slider_size, 0, slider_size, slider_size);
-    
+    mRangeSlider->setPopupDisplayEnabled(true, true, nullptr);
     addAndMakeVisible(*mRangeSlider);
     
     mBlendSlider.reset(new HairballParameterSlider(mProcessor->parameters, HairballParameterID[hParameter_Blend], HairballParameterLabel[hParameter_Blend]));
     mBlendSlider->setBounds(0, getHeight() - slider_size, slider_size, slider_size);
+    mBlendSlider->setPopupDisplayEnabled(true, true, nullptr);
     addAndMakeVisible(*mBlendSlider);
     
     mVolumeSlider.reset(new HairballParameterSlider(mProcessor->parameters, HairballParameterID[hParameter_Volume], HairballParameterLabel[hParameter_Volume]));
     mVolumeSlider->setBounds(getWidth() - slider_size, getHeight() - slider_size, slider_size, slider_size);
+    mVolumeSlider->setPopupDisplayEnabled(true, true, nullptr);
     
     addAndMakeVisible(*mVolumeSlider);
     addMouseListener(this, true);


### PR DESCRIPTION
This is in preparation for #5. The range, blend and volume param vals were not showing in the default popup.